### PR TITLE
Update manifests/init.pp to handle negative values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ case $operatingsystem {
               TRUE => "defaults read $domain $key | grep -qx 1",
               FALSE => "defaults read $domain $key | grep -qx 0"
               },
-          default => "defaults read $domain $key | grep -qx $value"
+          default => "defaults read $domain $key | grep -qx -e $value"
         }
       }
     }


### PR DESCRIPTION
adding the -e switch to the defaults read line: this tells grep that the next text is definitely the pattern to find.
This fixes an issue with values that begin with the '-' character, in my case a -1.
