### PR TITLE
Used a legal resource name

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'grahamgilbert-macdefaults'
-version '0.0.1'
+version '1.0.0'
 summary 'Manage defaults on an OS X system'
 author 'Graham Gilbert'
 source 'https://github.com/pebbleit/puppet-macdefaults.git'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ case $operatingsystem {
               'TRUE' => "defaults read $domain $key | grep -qx 1",
               'FALSE' => "defaults read $domain $key | grep -qx 0"
               },
-          default => "defaults read $domain $key | grep -qx $value | sed -e 's/ (.*)/\1/'"
+          default => "defaults read $domain $key | grep -qx $value | sed -e 's/ (.*)/\\1/'"
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # Note that type can be one of:
 # string, data, int, float, bool, data, array, array-add, dict, dict-add
-define mac-defaults($domain, $key, $value = false, $type = "string", $action = "write") {
+define mac_defaults($domain, $key, $value = false, $type = "string", $action = "write") {
 case $operatingsystem {
  Darwin:{
   case $action {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 # string, data, int, float, bool, data, array, array-add, dict, dict-add
 define mac_defaults($domain, $key, $value = false, $type = "string", $action = "write") {
 case $operatingsystem {
- Darwin:{
+ 'Darwin':{
   case $action {
     "write": {
       exec {"defaults write $domain $key -$type '$value'":


### PR DESCRIPTION
According to the [acceptable variable names](https://puppet.com/docs/puppet/5.3/lang_reserved.html#variables), `mac-defaults` is not a legal name for `define`.

Error under puppet 4.10.4:
```
Error: Unacceptable name. The name 'mac-defaults' is unacceptable as the name of a 'define' expression
```